### PR TITLE
using monospace typeface in order to avoid ace cursor position problem

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -40,7 +40,7 @@ body {
 }
 
 .ace_editor {
-  font-family: 'Courier';
+  font-family: "Courier New", Courier, "Lucida Sans Typewriter", "Lucida Typewriter", monospace;
   display: block;
   height: calc(100vh - 200px);
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -40,6 +40,7 @@ body {
 }
 
 .ace_editor {
+  font-family: 'Courier';
   display: block;
   height: calc(100vh - 200px);
 }


### PR DESCRIPTION
Workaround to issue #32 