### PR TITLE
Fix crashing on highlighting an unsupported language

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -132,7 +132,15 @@ class Renderer {
       smartLists: true,
       breaks: false,
       smartypants: true,
-      highlight: (code, lang) => lang && lang !== 'no-highlight' ? highlight.highlight(lang, code, true).value : code
+      highlight: (code, lang) => {
+        try {
+          code = lang && lang !== 'no-highlight' ? highlight.highlight(lang, code, true).value : code;
+        } catch {
+          console.error(`Unsupported language for highlighting: ${lang}`);
+        }
+
+        return code;
+      }
     });
   }
 


### PR DESCRIPTION
**Issue**
There is a block of code in the markdown document for example:

>**```[language]**
>
>Some text here
>
>**```**

If the [language] is not supported by highlight.js, the `highlight.highlight()` throws an exception and the rendering crashes. The browser gets an error `Cannot GET ` with the code `404 Not Found`.

**Suggested fix**
Add a try-catch block when calling highlight method.
Render a plain text and throw an error log instead of interrupting a renderer.